### PR TITLE
Use simpler match query

### DIFF
--- a/pylibs/notmuch_abook.py
+++ b/pylibs/notmuch_abook.py
@@ -155,7 +155,9 @@ class SQLiteStorage():
         """
         with self.connect() as c:
             cur = c.cursor()
-            for res in cur.execute("SELECT * FROM addressBook WHERE name MATCH '%s*' UNION SELECT * FROM addressBook WHERE address MATCH '%s*'""" % (match, match)).fetchall():
+            for res in cur.execute(
+                    "SELECT * FROM AddressBook WHERE AddressBook MATCH '%s'"
+                    % match).fetchall():
                 yield res
 
 


### PR DESCRIPTION
When using fts (full text search) there is a hidden field with the table name
that can be used to match text in any field.  So use that field rather than
doing a union.
