### PR TITLE
Improve email address parsing

### DIFF
--- a/pylibs/notmuch_abook.py
+++ b/pylibs/notmuch_abook.py
@@ -45,8 +45,8 @@ class MailParser(object):
 
     def parse_mail(self, m):
         """
-        function used to extract headers from a email.message or notmuch.message email object
-        yields address tuples
+        function used to extract headers from a email.message or
+        notmuch.message email object yields address tuples
         """
         addrs = []
         if isinstance(m, email.message.Message):
@@ -55,14 +55,15 @@ class MailParser(object):
             get_header = m.get_header
         for h in ('to', 'from', 'cc', 'bcc'):
             v = get_header(h)
-            if v > '':
+            if v:
                 addrs.append(v)
         for addr in email.utils.getaddresses(addrs):
-            if addr[1] != "" and not addr[1] in self.addresses.keys():
-                addr = (addr[0].strip("'").strip('"').strip(" "), addr[1])
-                self.addresses[addr[1]] = addr[0]
-                for w in addr[0].split(" ") + [addr[1]]:
-                    yield addr
+            name = addr[0].strip('; ')
+            address = addr[1].lower().strip(';\'" ')
+            if (address and address not in self.addresses):
+                self.addresses[address] = name
+                yield (name, address)
+
 
 class NotmuchAddressGetter(object):
     """Get all addresses from notmuch, based on information information from


### PR DESCRIPTION
- strip semicolons off both name and address
- single strip call for each
- lower case the email address for consistency

I've also put named variables in for name and address to make the code more
readable.

Finally I got rid of an inner for loop that appeared to yield the same result
repeatedly.  The loop was:

```
for w in addr[0].split(" ") + [addr[1]]:
    yield addr
```

As w wasn't used in the loop, that will just yield the same value each time.
If this was meant to do something else, please say.
