### PR TITLE
Allow duplicate names into database

### DIFF
--- a/pylibs/notmuch_abook.py
+++ b/pylibs/notmuch_abook.py
@@ -116,8 +116,7 @@ class SQLiteStorage():
                                   "BEGIN"+
                                   " SELECT RAISE(ABORT, 'column name is not unique')"+
                                   "   FROM addressbook"+
-                                  "  WHERE name = new.name"+
-                                  "     OR address = new.address;"+
+                                  "  WHERE address = new.address;"+
                                   " INSERT INTO addressbook VALUES(new.name, new.address);"+
                                   "END;")
 


### PR DESCRIPTION
By making sqlite not throw an error when the name is a duplicate.

Fixes issue #5
