### PR TITLE
Fix lookup query

### DIFF
--- a/pylibs/notmuch_abook.py
+++ b/pylibs/notmuch_abook.py
@@ -156,7 +156,7 @@ class SQLiteStorage():
         with self.connect() as c:
             cur = c.cursor()
             for res in cur.execute(
-                    "SELECT * FROM AddressBook WHERE AddressBook MATCH '%s'"
+                """SELECT * FROM AddressBook WHERE AddressBook MATCH '"%s*"'"""
                     % match).fetchall():
                 yield res
 


### PR DESCRIPTION
Re-add the \* that allows partial word look ups, and also add quotes so
that the multi word look up works.  Without the quotes then 'tom d_'
will match a name with 'tom' in it and an address with 'd' in it.  With
the quotes, '"tom d_"' will only match names that start with the 5
characters 'tom d'.

This allows multi-word completion in my testing - so solves issue #8
