### PR TITLE
fix UnicodeEncodeError when printing matches

### DIFF
--- a/pylibs/notmuch_abook.py
+++ b/pylibs/notmuch_abook.py
@@ -347,7 +347,8 @@ def print_address_list(address_list, output_format, out=None):
             return
     else:
         for address in address_list:
-            out.write(format_address(address, output_format) + '\n')
+            output = format_address(address, output_format).encode('utf-8')
+            out.write(output + '\n')
 
 
 def import_address_list_from_csv(db, replace_all, infile):


### PR DESCRIPTION
Steps to reproduce:

Put names with unicode chars in address book, e.g.:

```
Janíčko Hraško <janko@hrasko.asd>
```

Query database like this:

```
subprocess.check_output(['notmuch_abook.py', '--verbose', 'lookup', 'hra'])
```

```
Traceback (most recent call last):
  File "/home/ttomecek/dev/notmuch-abook/pylibs/notmuch_abook.py", line 464, in run
    lookup_action(db, options['<match>'], options['--format'])
  File "/home/ttomecek/dev/notmuch-abook/pylibs/notmuch_abook.py", line 401, in lookup_action
    print_address_list(db.lookup(match), output_format)
  File "/home/ttomecek/dev/notmuch-abook/pylibs/notmuch_abook.py", line 354, in print_address_list
    o = format_address(address, output_format).decode('ascii')
UnicodeEncodeError: 'ascii' codec can't encode character u'\u0159' in position 3: ordinal not in range(128)
```

This happened to me in [alot](https://github.com/pazz/alot) MUA.
