### PR TITLE
Complete for .eml extensions as well

### DIFF
--- a/plugin/notmuch_abook.vim
+++ b/plugin/notmuch_abook.vim
@@ -65,6 +65,8 @@ endfun
 
 augroup notmuchabook
     au!
+    au FileType eml call InitAddressBook()
+    au FileType eml setlocal completefunc=CompleteAddressBook
     au FileType mail call InitAddressBook()
     au FileType mail setlocal completefunc=CompleteAddressBook
 augroup END


### PR DESCRIPTION
Some editors create emails with `.eml` extension ([alot](https://github.com/pazz/alot)), so setup the completions in those files as well.