### PR TITLE
Support @imain's updates of notmuch

### DIFF
--- a/plugin/notmuch_abook.vim
+++ b/plugin/notmuch_abook.vim
@@ -65,9 +65,7 @@ endfun
 
 augroup notmuchabook
     au!
-    au FileType mail call InitAddressBook()
-    au FileType mail setlocal completefunc=CompleteAddressBook
-    au FileType notmuch-compose call InitAddressBook()
-    au FileType notmuch-compose setlocal completefunc=CompleteAddressBook
+    au FileType mail,notmuch-compose call InitAddressBook()
+    au FileType mail,notmuch-compose setlocal completefunc=CompleteAddressBook
 augroup END
 

--- a/plugin/notmuch_abook.vim
+++ b/plugin/notmuch_abook.vim
@@ -67,5 +67,7 @@ augroup notmuchabook
     au!
     au FileType mail call InitAddressBook()
     au FileType mail setlocal completefunc=CompleteAddressBook
+    au FileType notmuch-compose call InitAddressBook()
+    au FileType notmuch-compose setlocal completefunc=CompleteAddressBook
 augroup END
 


### PR DESCRIPTION
`notmuch-vim` uses `notmuch-compose` as FileType when composing e-mail. @imain suggested adding those two lines to enable support in abook.

[Cfr. this issue report of mine](https://github.com/imain/notmuch-vim/issues/20)