### PR TITLE
Use Python 3 if Vim was build with -python +python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Notmuch Addressbook manager for vim
 DEPENDENCES
 -----------
 
-* notmuch with python bindings
+* notmuch with python or python3 bindings
 
 INSTALL
 -------

--- a/pythonx/notmuch_abook.py
+++ b/pythonx/notmuch_abook.py
@@ -104,7 +104,7 @@ class NotMuchConfig(object):
             config_file = os.environ.get('NOTMUCH_CONFIG', '~/.notmuch-config')
 
         # set a default for ignorefile
-        self.config = configparser.ConfigParser({'ignorefile': None})
+        self.config = configparser.ConfigParser({'ignorefile': ''})
         self.config.read(os.path.expanduser(config_file))
 
     def get(self, section, key):


### PR DESCRIPTION
As the title says, this allows you to use notmuch-abook with a Vim build without Python 2 but with Python 3 support. Unfortunately, I don't know how to support both Python 2 and 3 without the code duplication.