### PR TITLE
Fix import of a new address (without `--replace` option)

### DIFF
--- a/pythonx/notmuch_abook.py
+++ b/pythonx/notmuch_abook.py
@@ -263,7 +263,8 @@ class SQLiteStorage():
             with self.connect() as c:
                 cur = c.cursor()
                 if replace:
-                    present = cur.execute("SELECT 1 FROM AddressBook WHERE address = ?", [addr[1]])
+                    cur.execute("SELECT 1 FROM AddressBook WHERE address = ?", [addr[1]])
+                    present = cur.fetchone()
                     if present:
                         cur.execute("UPDATE AddressBook SET name = ? WHERE address = ?", addr)
                     else:


### PR DESCRIPTION
The `execute` method does not have a significant result value. The
`present` variable just contains the cursor object, which is always
`true`. Therefore the else-case for creating a new address entry can't
be reached.

To fix the behavior we need to fetch the result of the select statement.
If the statement doesn't match anything the fetched result will be
`None` which evaluates to `false` and leads to creation of a new address
entry.